### PR TITLE
Implementation-of-div_u.i32

### DIFF
--- a/cmd/wasmvm/main.go
+++ b/cmd/wasmvm/main.go
@@ -22,19 +22,19 @@ func main() {
 		os.Exit(1)
 	}
 	// Preload some instructions for testing
-	vm.Memory[0] = 0x01 // NOP
-	vm.Memory[1] = 0x41 // const.i32
-	vm.Memory[2] = 2    // Little Endian a
-	vm.Memory[3] = 0    //
-	vm.Memory[4] = 0    //
+	vm.Memory[0] = wasmvm.OP_NOP       // NOP
+	vm.Memory[1] = wasmvm.OP_CONST_I32 // const.i32
+	vm.Memory[2] = 2                   // Little Endian a
+	vm.Memory[3] = 0                   //
+	vm.Memory[4] = 0                   //
 	vm.Memory[5] = 0
-	vm.Memory[6] = 0x41 // const.i32
-	vm.Memory[7] = 3    // Little Endian b
+	vm.Memory[6] = wasmvm.OP_CONST_I32 // const.i32
+	vm.Memory[7] = 3                   // Little Endian b
 	vm.Memory[8] = 0
 	vm.Memory[9] = 0
 	vm.Memory[10] = 0
-	vm.Memory[11] = 0x6A // add.i32
-	vm.Memory[12] = 0x0B // END: Let's blow this popcicle stand
+	vm.Memory[11] = wasmvm.OP_ADD_I32 // add.i32
+	vm.Memory[12] = wasmvm.OP_END     // END: Let's blow this popcicle stand
 	// Set PC to 0
 	vm.PC = 0
 	vm.MainLoop()

--- a/pkg/wasmvm/instruct_numeric_i32_test.go
+++ b/pkg/wasmvm/instruct_numeric_i32_test.go
@@ -258,3 +258,18 @@ func TestMUL_I32_OverflowWrap(t *testing.T) {
 	assert.Equal(t, uint64(1), vm.PC)
 	assert.Equal(t, 0, vm.ValueStack.Size())
 }
+
+func TestDIV_I32_DivideByZero(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(1) // DWORD decimal -1
+	vm.ValueStack.PushInt32(0)
+	vm.Memory[0] = 0x6E
+	vm.PC = 0
+	err = vm.Step()
+	assert.Error(t, err)
+	assert.Equal(t, 0, vm.ValueStack.Size())
+	assert.True(t, vm.Trap)
+	assert.Equal(t, "DIVU_I32: Divide by Zero", vm.TrapReason)
+}

--- a/pkg/wasmvm/instruct_numeric_i32_test.go
+++ b/pkg/wasmvm/instruct_numeric_i32_test.go
@@ -13,7 +13,7 @@ func TestCONST_I32(t *testing.T) {
 	}
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
-	vm.Memory[0] = 0x41 // Opcode
+	vm.Memory[0] = wasmvm.OP_CONST_I32 // Opcode
 	vm.Memory[1] = 0x78
 	vm.Memory[2] = 0x56
 	vm.Memory[3] = 0x34
@@ -35,7 +35,7 @@ func TestCONST_I32_OOB(t *testing.T) {
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
 
-	vm.Memory[0] = 0x41 // Opcode
+	vm.Memory[0] = wasmvm.OP_CONST_I32 // Opcode
 	vm.Memory[1] = 0x78
 	vm.Memory[2] = 0x56
 	vm.PC = 0
@@ -54,7 +54,7 @@ func TestADD_I32_NotEnoughStack(t *testing.T) {
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
 	// opcode
-	vm.Memory[0] = 0x6A
+	vm.Memory[0] = wasmvm.OP_ADD_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
@@ -73,7 +73,7 @@ func TestADD_I32_SmallNumbers(t *testing.T) {
 	vm.ValueStack.PushInt32(5)
 	vm.ValueStack.PushInt32(7)
 	// opcode
-	vm.Memory[0] = 0x6A
+	vm.Memory[0] = wasmvm.OP_ADD_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -93,7 +93,7 @@ func TestADD_I32_OverflowWrap(t *testing.T) {
 	vm.ValueStack.PushInt32(0xFFFFFFFF)
 	vm.ValueStack.PushInt32(2)
 	// opcode
-	vm.Memory[0] = 0x6A
+	vm.Memory[0] = wasmvm.OP_ADD_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -111,7 +111,7 @@ func TestSUB_I32_NotEnoughStack(t *testing.T) {
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
 	// opcode
-	vm.Memory[0] = 0x6B
+	vm.Memory[0] = wasmvm.OP_SUB_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
@@ -129,7 +129,7 @@ func TestSUB_I32_SmallNumbers(t *testing.T) {
 	vm.ValueStack.PushInt32(7)
 	vm.ValueStack.PushInt32(5)
 	// opcode
-	vm.Memory[0] = 0x6B
+	vm.Memory[0] = wasmvm.OP_SUB_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -149,7 +149,7 @@ func TestSUB_I32_OverflowWrap(t *testing.T) {
 	vm.ValueStack.PushInt32(1)
 	vm.ValueStack.PushInt32(2)
 	// opcode
-	vm.Memory[0] = 0x6B
+	vm.Memory[0] = wasmvm.OP_SUB_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -164,7 +164,7 @@ func TestMUL_I32_NotEnoughStack(t *testing.T) {
 	cfg := &wasmvm.VMConfig{Size: 1}
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
-	vm.Memory[0] = 0x6C // MUL_I32
+	vm.Memory[0] = wasmvm.OP_MUL_I32 // MUL_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
@@ -179,7 +179,7 @@ func TestMUL_I32_MultiplyByZero(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt32(12345)
 	vm.ValueStack.PushInt32(0)
-	vm.Memory[0] = 0x6C
+	vm.Memory[0] = wasmvm.OP_MUL_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -196,7 +196,7 @@ func TestMUL_I32_MultiplyByOne(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt32(1)
 	vm.ValueStack.PushInt32(0x12345678)
-	vm.Memory[0] = 0x6C
+	vm.Memory[0] = wasmvm.OP_MUL_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -213,7 +213,7 @@ func TestMUL_I32_PositiveTimesNegative(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt32(7)
 	vm.ValueStack.PushInt32(0xFFFFFFFD) // DWORD decimal -3
-	vm.Memory[0] = 0x6C
+	vm.Memory[0] = wasmvm.OP_MUL_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -230,7 +230,7 @@ func TestMUL_I32_NegativeTimesNegative(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt32(0xFFFFFFFE) // DWORD decimal -2
 	vm.ValueStack.PushInt32(0xFFFFFFFC) // DWORD decimal -4
-	vm.Memory[0] = 0x6C
+	vm.Memory[0] = wasmvm.OP_MUL_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -247,7 +247,7 @@ func TestMUL_I32_OverflowWrap(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt32(0xFFFFFFFF) // DWORD decimal -1
 	vm.ValueStack.PushInt32(2)
-	vm.Memory[0] = 0x6C
+	vm.Memory[0] = wasmvm.OP_MUL_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -259,17 +259,139 @@ func TestMUL_I32_OverflowWrap(t *testing.T) {
 	assert.Equal(t, 0, vm.ValueStack.Size())
 }
 
-func TestDIV_I32_DivideByZero(t *testing.T) {
+func TestDIVU_I32_DivideByZero(t *testing.T) {
 	cfg := &wasmvm.VMConfig{Size: 1}
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
-	vm.ValueStack.PushInt32(1) // DWORD decimal -1
+	vm.ValueStack.PushInt32(1)
 	vm.ValueStack.PushInt32(0)
-	vm.Memory[0] = 0x6E
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
 	assert.Equal(t, 0, vm.ValueStack.Size())
 	assert.True(t, vm.Trap)
 	assert.Equal(t, "DIVU_I32: Divide by Zero", vm.TrapReason)
+}
+
+func TestDIVU_I32_StackUnderflow(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(1)
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.Error(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	assert.True(t, vm.Trap)
+	assert.Equal(t, "DIVU_I32: Stack Underflow", vm.TrapReason)
+}
+
+func TestDIVU_I32_SmallValues(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(10)
+	vm.ValueStack.PushInt32(5)
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	val, ok := vm.ValueStack.Pop()
+	assert.True(t, ok)
+	assert.Equal(t, uint32(2), val.Value_I32)
+	assert.Equal(t, uint64(1), vm.PC)
+	assert.Equal(t, 0, vm.ValueStack.Size())
+}
+
+func TestDIVU_I32_DivideByOne(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(42)
+	vm.ValueStack.PushInt32(1)
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	val, ok := vm.ValueStack.Pop()
+	assert.True(t, ok)
+	assert.Equal(t, uint32(42), val.Value_I32)
+	assert.Equal(t, uint64(1), vm.PC)
+	assert.Equal(t, 0, vm.ValueStack.Size())
+}
+
+func TestDIVU_I32_DivisorLargerThanDividend(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(42)
+	vm.ValueStack.PushInt32(137)
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	val, ok := vm.ValueStack.Pop()
+	assert.True(t, ok)
+	assert.Equal(t, uint32(0), val.Value_I32)
+	assert.Equal(t, uint64(1), vm.PC)
+	assert.Equal(t, 0, vm.ValueStack.Size())
+}
+
+func TestDIVU_I32_ZeroDividend(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(0)
+	vm.ValueStack.PushInt32(137)
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	val, ok := vm.ValueStack.Pop()
+	assert.True(t, ok)
+	assert.Equal(t, uint32(0), val.Value_I32)
+	assert.Equal(t, uint64(1), vm.PC)
+	assert.Equal(t, 0, vm.ValueStack.Size())
+}
+
+func TestDIVU_I32_MaxValueBySelf(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(^uint32(0))
+	vm.ValueStack.PushInt32(^uint32(0))
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	val, ok := vm.ValueStack.Pop()
+	assert.True(t, ok)
+	assert.Equal(t, uint32(1), val.Value_I32)
+	assert.Equal(t, uint64(1), vm.PC)
+	assert.Equal(t, 0, vm.ValueStack.Size())
+}
+
+func TestDIVU_I32_MaxValueByOnef(t *testing.T) {
+	cfg := &wasmvm.VMConfig{Size: 1}
+	vm, err := wasmvm.NewVM(cfg)
+	assert.NoError(t, err)
+	vm.ValueStack.PushInt32(^uint32(0))
+	vm.ValueStack.PushInt32(1)
+	vm.Memory[0] = wasmvm.OP_DIVU_I32
+	vm.PC = 0
+	err = vm.Step()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, vm.ValueStack.Size())
+	val, ok := vm.ValueStack.Pop()
+	assert.True(t, ok)
+	assert.Equal(t, ^uint32(0), val.Value_I32)
+	assert.Equal(t, uint64(1), vm.PC)
+	assert.Equal(t, 0, vm.ValueStack.Size())
 }

--- a/pkg/wasmvm/instruct_numeric_i64.go
+++ b/pkg/wasmvm/instruct_numeric_i64.go
@@ -23,7 +23,7 @@ func CONST_I64(vm *VMState) error {
 	return nil
 }
 
-// 0x7C add.i32: Pull two I64 words off stack, push I64 sum word on stack
+// 0x7C add.i64: Pull two I64 words off stack, push I64 sum word on stack
 func ADD_I64(vm *VMState) error {
 	enough, collect := vm.ValueStack.HasAtLeastOfType(2, TYPE_I64)
 	if !enough {
@@ -44,7 +44,7 @@ func ADD_I64(vm *VMState) error {
 	return nil
 }
 
-// 0x7D sub.i32: Pull two I64 words off stack, push I64 difference word on stack
+// 0x7D sub.i64: Pull two I64 words off stack, push I64 difference word on stack
 func SUB_I64(vm *VMState) error {
 	enough, collect := vm.ValueStack.HasAtLeastOfType(2, TYPE_I64)
 	if !enough {

--- a/pkg/wasmvm/instruct_numeric_i64_test.go
+++ b/pkg/wasmvm/instruct_numeric_i64_test.go
@@ -13,7 +13,7 @@ func TestCONST_I64(t *testing.T) {
 	}
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
-	vm.Memory[0] = 0x42 // Opcode
+	vm.Memory[0] = wasmvm.OP_CONST_I64 // Opcode
 	vm.Memory[1] = 0xEF
 	vm.Memory[2] = 0xCD
 	vm.Memory[3] = 0xAB
@@ -39,7 +39,7 @@ func TestCONST_I64_OOB(t *testing.T) {
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
 
-	vm.Memory[0] = 0x42 // Opcode
+	vm.Memory[0] = wasmvm.OP_CONST_I64 // Opcode
 	vm.Memory[1] = 0x78
 	vm.Memory[2] = 0x56
 	vm.PC = 0
@@ -58,7 +58,7 @@ func TestADD_I64_NotEnoughStack(t *testing.T) {
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
 	// opcode
-	vm.Memory[0] = 0x7C
+	vm.Memory[0] = wasmvm.OP_ADD_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
@@ -77,7 +77,7 @@ func TestADD_I64_SmallNumbers(t *testing.T) {
 	vm.ValueStack.PushInt64(5)
 	vm.ValueStack.PushInt64(7)
 	// opcode
-	vm.Memory[0] = 0x7C
+	vm.Memory[0] = wasmvm.OP_ADD_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -97,7 +97,7 @@ func TestADD_I64_OverflowWrap(t *testing.T) {
 	vm.ValueStack.PushInt64(^uint64(0)) // I didn't feel like typing a bunch of f's
 	vm.ValueStack.PushInt64(2)
 	// opcode
-	vm.Memory[0] = 0x7C
+	vm.Memory[0] = wasmvm.OP_ADD_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -115,7 +115,7 @@ func TestSUB_I64_NotEnoughStack(t *testing.T) {
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
 	// opcode
-	vm.Memory[0] = 0x7D
+	vm.Memory[0] = wasmvm.OP_SUB_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
@@ -133,7 +133,7 @@ func TestSUB_I64_SmallNumbers(t *testing.T) {
 	vm.ValueStack.PushInt64(7)
 	vm.ValueStack.PushInt64(5)
 	// opcode
-	vm.Memory[0] = 0x7D
+	vm.Memory[0] = wasmvm.OP_SUB_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -153,7 +153,7 @@ func TestSUB_I64_OverflowWrap(t *testing.T) {
 	vm.ValueStack.PushInt64(1)
 	vm.ValueStack.PushInt64(2)
 	// opcode
-	vm.Memory[0] = 0x7D
+	vm.Memory[0] = wasmvm.OP_SUB_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -168,7 +168,7 @@ func TestMUL_I64_NotEnoughStack(t *testing.T) {
 	cfg := &wasmvm.VMConfig{Size: 1}
 	vm, err := wasmvm.NewVM(cfg)
 	assert.NoError(t, err)
-	vm.Memory[0] = 0x7E // MUL_I64
+	vm.Memory[0] = wasmvm.OP_MUL_I64 // MUL_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.Error(t, err)
@@ -183,7 +183,7 @@ func TestMUL_I64_MultiplyByZero(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt64(12345)
 	vm.ValueStack.PushInt64(0)
-	vm.Memory[0] = 0x7E
+	vm.Memory[0] = wasmvm.OP_MUL_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -200,7 +200,7 @@ func TestMUL_I64_MultiplyByOne(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt64(1)
 	vm.ValueStack.PushInt64(0x0123456789ABCDEF)
-	vm.Memory[0] = 0x7E
+	vm.Memory[0] = wasmvm.OP_MUL_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -217,7 +217,7 @@ func TestMUL_I64_PositiveTimesNegative(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt64(7)
 	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFD) // QWORD decimal -3
-	vm.Memory[0] = 0x7E
+	vm.Memory[0] = wasmvm.OP_MUL_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -234,7 +234,7 @@ func TestMUL_I64_NegativeTimesNegative(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFE) // QWORD decimal -2
 	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFC) // QWORD decimal -4
-	vm.Memory[0] = 0x7E
+	vm.Memory[0] = wasmvm.OP_MUL_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)
@@ -251,7 +251,7 @@ func TestMUL_I64_OverflowWrap(t *testing.T) {
 	assert.NoError(t, err)
 	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFF) // QWORD decimal -1
 	vm.ValueStack.PushInt64(2)
-	vm.Memory[0] = 0x7E
+	vm.Memory[0] = wasmvm.OP_MUL_I64
 	vm.PC = 0
 	err = vm.Step()
 	assert.NoError(t, err)

--- a/pkg/wasmvm/instruction.go
+++ b/pkg/wasmvm/instruction.go
@@ -2,18 +2,39 @@ package wasmvm
 
 type Instruction func(*VMState) error
 
+const (
+	// Control Instructions
+	OP_NOP = 0x01
+	OP_END = 0x0B
+
+	// Numeric instructions
+	OP_CONST_I32 = 0x41
+	OP_CONST_I64 = 0x42
+
+	// Numeric i32 arithmatic instructions
+	OP_ADD_I32  = 0x6A
+	OP_SUB_I32  = 0x6B
+	OP_MUL_I32  = 0x6C
+	OP_DIVU_I32 = 0x6E
+
+	// Numeric I64 arithmatic instructions
+	OP_ADD_I64 = 0x7C
+	OP_SUB_I64 = 0x7D
+	OP_MUL_I64 = 0x7E
+)
+
 func defaultInstructionMap() map[uint8]Instruction {
 	return map[uint8]Instruction{
-		0x01: NOP,
-		0x0B: END, // End of function
-		0x41: CONST_I32,
-		0x42: CONST_I64,
-		0x6A: ADD_I32,
-		0x6B: SUB_I32,
-		0x6C: MUL_I32,
-		0x6E: DIVU_I32,
-		0x7C: ADD_I64,
-		0x7D: SUB_I64,
-		0x7E: MUL_I64,
+		OP_NOP:       NOP,
+		OP_END:       END, // End of function
+		OP_CONST_I32: CONST_I32,
+		OP_CONST_I64: CONST_I64,
+		OP_ADD_I32:   ADD_I32,
+		OP_SUB_I32:   SUB_I32,
+		OP_MUL_I32:   MUL_I32,
+		OP_DIVU_I32:  DIVU_I32,
+		OP_ADD_I64:   ADD_I64,
+		OP_SUB_I64:   SUB_I64,
+		OP_MUL_I64:   MUL_I64,
 	}
 }

--- a/pkg/wasmvm/instruction.go
+++ b/pkg/wasmvm/instruction.go
@@ -11,6 +11,7 @@ func defaultInstructionMap() map[uint8]Instruction {
 		0x6A: ADD_I32,
 		0x6B: SUB_I32,
 		0x6C: MUL_I32,
+		0x6E: DIVU_I32,
 		0x7C: ADD_I64,
 		0x7D: SUB_I64,
 		0x7E: MUL_I64,


### PR DESCRIPTION
Includes the full implementation of div_u.i32 with unit tests, in addtion, done the following:

For ease of maintaince, made the opcodes as const in instruction.go (certainly makes the unit tests easier and less error prone).

Updated the main.go test executable.

Overall coverage should be appoximately 85% to 86%, with the pkg at 94.6%. The coverage of the Drop() statements adds up after a while.