### PR TITLE
Includes the div_s.i32 instruction along with unit test.

### DIFF
--- a/pkg/wasmvm/instruct_numeric_i32.go
+++ b/pkg/wasmvm/instruct_numeric_i32.go
@@ -3,6 +3,7 @@ package wasmvm
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"math/bits"
 )
 
@@ -83,7 +84,64 @@ func MUL_I32(vm *VMState) error {
 	return nil
 }
 
-// 0x6E div_u.i32: Pull two I32 words off stack, push I32 quotient word on stack
+// 0x6D div_s.i32: Pull two I32 words off stack, push I32 quotient word on stack (signed)
+func DIVS_I32(vm *VMState) error {
+	enough, collect := vm.ValueStack.HasAtLeastOfType(2, TYPE_I32)
+	if !enough {
+		return NewStackUnderflowErrorAndSetTrapReason(vm, "DIVS_I32")
+	}
+
+	// I'm not even sure how I can write an unit test for this
+	// one, especially since there is no multithreading and
+	// the instruction treats it as an atomic operation
+	if !vm.ValueStack.Drop(2, true) {
+		return NewStackCleanupErrorAndSetTrapReason(vm, "DIVS_I32")
+	}
+
+	// Cheap cast for getting signed version
+	// Note that the way the stack works is non-intuitive since
+	// I use a slice... The top of the stack is at the end of the array
+	sdividend := int32(collect[0].Value_I32)
+	sdivisor := int32(collect[1].Value_I32)
+
+	if sdivisor == 0 {
+		vm.Trap = true
+		vm.TrapReason = "DIVS_I32: Divide by Zero"
+		return errors.New(vm.TrapReason)
+	}
+
+	// Referencing https://webassembly.github.io/spec/core/exec/numerics.html#op-idiv-s
+	// This line suggests to me that overflow should be rejected
+	// Else if j_2 divided by j_2 is 2^{N-1}, then the result is undefined.
+	// For now, I'll trap like Divide by Zero
+
+	if sdividend == math.MinInt32 && sdivisor == -1 { // This should be overflow
+		vm.Trap = true
+		vm.TrapReason = "DIVS_I32: Signed Division Overflow"
+		return errors.New(vm.TrapReason)
+	}
+
+	// I took a gander at Knunth vol 2, p 276. It looks like since 2's compliment
+	// I can just do the math as unsigned after accounting for overflow and then
+	// set the sign based on the effective signs of the original
+	//
+	// The whole thing seemed more complicated than necessary, so I'm just doing division
+	// using int64 for int32, and coercing it back to uint32.
+	// This means I'll need to look at it again for div_s.i64, since I haven't found int128
+	// An additional look at bits.Div64 seems to suggest it's just Knuth Algorith D
+	// Or some variant there of, see page 272 of 3rd edition.
+	// But here, no need to work harder than need be
+
+	accumulator := uint32(int64(sdividend) / int64(sdivisor))
+
+	// As usual, I have to use uint32 for the stack itself since it's sign agnostic.
+	// Will need to make sure there is a unit test to ensure the high bit round trips
+	vm.ValueStack.PushInt32(uint32(accumulator))
+	vm.PC += 1
+	return nil
+}
+
+// 0x6E div_u.i32: Pull two I32 words off stack, push I32 quotient word on stack (unsigned)
 func DIVU_I32(vm *VMState) error {
 	enough, collect := vm.ValueStack.HasAtLeastOfType(2, TYPE_I32)
 	if !enough {

--- a/pkg/wasmvm/instruction.go
+++ b/pkg/wasmvm/instruction.go
@@ -15,6 +15,7 @@ const (
 	OP_ADD_I32  = 0x6A
 	OP_SUB_I32  = 0x6B
 	OP_MUL_I32  = 0x6C
+	OP_DIVS_I32 = 0x6D
 	OP_DIVU_I32 = 0x6E
 
 	// Numeric I64 arithmatic instructions
@@ -33,6 +34,7 @@ func defaultInstructionMap() map[uint8]Instruction {
 		OP_ADD_I32:   ADD_I32,
 		OP_SUB_I32:   SUB_I32,
 		OP_MUL_I32:   MUL_I32,
+		OP_DIVS_I32:  DIVS_I32,
 		OP_DIVU_I32:  DIVU_I32,
 		OP_ADD_I64:   ADD_I64,
 		OP_SUB_I64:   SUB_I64,

--- a/pkg/wasmvm/vm_valuestack.go
+++ b/pkg/wasmvm/vm_valuestack.go
@@ -73,6 +73,10 @@ func (vs *ValueStack) Size() int {
 	return len(vs.elements)
 }
 
+// If the last n values on the stack are not of ValueStackEntryType entryType
+// returns false, nil
+// Otherwise returns true, []ValueStackEntry as a slice of the stack
+// Please note that the top of the stack is at the end of the array
 func (vs *ValueStack) HasAtLeastOfType(cnt int, entryType ValueStackEntryType) (bool, []ValueStackEntry) {
 	if !vs.HasAtLeast(cnt) {
 		return false, nil

--- a/pkg/wasmvm/vm_valuestack_test.go
+++ b/pkg/wasmvm/vm_valuestack_test.go
@@ -56,6 +56,22 @@ func TestValueStack_HasAtLeastOfType(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestValueStack_HasAtLeastOfType_ManyValues(t *testing.T) {
+	vs := wasmvm.NewValueStack()
+	vs.PushInt32(uint32(1))
+	vs.PushInt32(uint32(2))
+	vs.PushInt64(^uint64(0))
+	vs.PushInt64(uint64(123))
+	vs.PushInt32(3)
+	vs.PushInt32(^uint32(0))
+	ok, collect := vs.HasAtLeastOfType(2, wasmvm.TYPE_I32)
+	assert.True(t, ok)
+	// Due to the way I implment things, the returns things
+	// opposite to intuition
+	assert.Equal(t, uint32(3), collect[0].Value_I32)
+	assert.Equal(t, ^uint32(0), collect[1].Value_I32)
+}
+
 func TestValueStack_Drop(t *testing.T) {
 	vs := wasmvm.NewValueStack()
 	vs.PushInt32(42)


### PR DESCRIPTION
 Unit test was done as a table driven test. ./pkg/wasmvm is approximately 93%.

Added additional comment and test case to vm_valuestack since the helper method's order might be unclear.