### PR TITLE
Used the i32 numeric test cases to bootstrap the i64 test cases.

### DIFF
--- a/pkg/wasmvm/instruct_numeric_i64.go
+++ b/pkg/wasmvm/instruct_numeric_i64.go
@@ -9,7 +9,7 @@ import (
 // 0x42 const.i64: reads 8 octets little endian and pushes unit64 to stack
 func CONST_I64(vm *VMState) error {
 	const width = 1 + WIDTH_I64
-	if vm.PC+width >= uint64(len(vm.Memory)) {
+	if vm.PC+width > uint64(len(vm.Memory)) {
 		vm.Trap = true
 		vm.TrapReason = "CONST_I64: Out of bounds"
 		return errors.New(vm.TrapReason)

--- a/pkg/wasmvm/instruct_numeric_i64_test.go
+++ b/pkg/wasmvm/instruct_numeric_i64_test.go
@@ -1,401 +1,576 @@
 package wasmvm_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/redmasq/rmq-wasm-vm/pkg/wasmvm"
 	"github.com/stretchr/testify/assert"
 )
 
+// For the i64 test cases
+type i64TestCase struct {
+	name          string   // Test case description
+	memoryContent []byte   // Initial memory content
+	expectTrap    bool     // Expect a trap error
+	trapReason    string   // Expected reason for trap, if any
+	expectValue   []uint64 // Expected value pushed on the stack
+	expectPC      uint64   // Expected program counter after execution
+	stackValues   []uint64
+	expectedStack int // Stack size after execution, before popping result
+}
+
+// runTestBatchI64 runs a suite of i64TestCase VM table tests and asserts expected VM and stack outcomes.
+func runTestBatchI64(t *testing.T, tests []i64TestCase) {
+	for i := range tests {
+		tc := tests[i]
+		name := tc.name
+		memorySize := uint64(len(tc.memoryContent))
+		t.Run(name, func(t *testing.T) {
+			// Initialize VM configuration
+			cfg := &wasmvm.VMConfig{
+				Size: memorySize,
+				Image: &wasmvm.ImageConfig{
+					Type:  "array",
+					Array: tc.memoryContent,
+					Size:  memorySize,
+				},
+			}
+			vm, err := wasmvm.NewVM(cfg)
+			assert.NoError(t, err)
+
+			// Push test values onto stack
+			for _, val := range tc.stackValues {
+				vm.ValueStack.PushInt64(val)
+			}
+
+			vm.PC = 0
+
+			err = vm.Step()
+
+			if tc.expectTrap {
+				assert.Error(t, err)
+				assert.True(t, vm.Trap)
+				assert.Equal(t, tc.trapReason, vm.TrapReason)
+				assert.Equal(t, tc.expectedStack, vm.ValueStack.Size())
+			} else {
+				assert.NoError(t, err)
+				assert.False(t, vm.Trap, "Trap was raised: "+vm.TrapReason)
+				if tc.expectedStack > 0 {
+					assert.Equal(t, tc.expectedStack, vm.ValueStack.Size())
+					for i := range tc.expectValue {
+						v := tc.expectValue[len(tc.expectValue)-i-1]
+						val, success := vm.ValueStack.Pop()
+						assert.True(t, success)
+						assert.Equal(t, v, val.Value_I64)
+					}
+				}
+				assert.Equal(t, tc.expectPC, vm.PC)
+			}
+		})
+	}
+}
+
+// Tests for const.i64
 func TestCONST_I64(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 10,
+	np := "CONST_I64: "
+	tests := []i64TestCase{
+		{
+			// Should accept little endian immediate value and place i64 on the stack
+			name:        np + "Happy Path",
+			stackValues: []uint64{},
+			memoryContent: []byte{
+				wasmvm.OP_CONST_I64, 0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0x123456789ABCDEF)},
+			expectPC:      9,
+			expectedStack: 1,
+		},
+		{
+			// This should detect a trap since there is no enough memory to finish the QWord
+			name:        np + "Out of Bounds",
+			stackValues: []uint64{},
+			memoryContent: []byte{
+				wasmvm.OP_CONST_I64, 0x78, 0x56,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Out of bounds",
+			expectPC:      0,
+			expectedStack: 0,
+		},
 	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.Memory[0] = wasmvm.OP_CONST_I64 // Opcode
-	vm.Memory[1] = 0xEF
-	vm.Memory[2] = 0xCD
-	vm.Memory[3] = 0xAB
-	vm.Memory[4] = 0x89
-	vm.Memory[5] = 0x67
-	vm.Memory[6] = 0x45
-	vm.Memory[7] = 0x23
-	vm.Memory[8] = 0x01
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, success := vm.ValueStack.Pop()
-	assert.True(t, success)
-	assert.Equal(t, uint64(9), vm.PC)
-	assert.Equal(t, uint64(0x0123456789ABCDEF), val.Value_I64)
-
+	runTestBatchI64(t, tests)
 }
 
-func TestCONST_I64_OOB(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 4,
+// Tests for add.i64
+func TestADD_I64(t *testing.T) {
+	np := "ADD_I64: "
+	tests := []i64TestCase{
+		{
+			// This should detect a trap since there is a lack of i64 values on the stack
+			name:        np + "Stack Underflow",
+			stackValues: []uint64{},
+			memoryContent: []byte{
+				wasmvm.OP_ADD_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Stack Underflow",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			// happy path - Small Numbers
+			name:        np + "Small Numbers",
+			stackValues: []uint64{uint64(5), uint64(7)},
+			memoryContent: []byte{
+				wasmvm.OP_ADD_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(12)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Overflow Wrap
+			// Going past 0xffffffffffffffff will wrap back to 0, or in this case for +2 to 1
+			name:        np + "Overflow Wrap",
+			stackValues: []uint64{^uint64(0), uint64(2)}, // ^uint64(0) or 0xffffffffffffffff is QWORD for -1
+			memoryContent: []byte{
+				wasmvm.OP_ADD_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(1)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
 	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-
-	vm.Memory[0] = wasmvm.OP_CONST_I64 // Opcode
-	vm.Memory[1] = 0x78
-	vm.Memory[2] = 0x56
-	vm.PC = 0
-	err = vm.Step()
-	assert.Error(t, err)
-	assert.Equal(t, int(0), vm.ValueStack.Size())
-	assert.True(t, vm.Trap)
-	assert.Equal(t, "CONST_I64: Out of bounds", vm.TrapReason)
-
+	runTestBatchI64(t, tests)
 }
 
-func TestADD_I64_NotEnoughStack(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 1,
+// Tests for sub.i64
+func TestSUB_I64(t *testing.T) {
+	np := "SUB_I64: "
+	tests := []i64TestCase{
+		{
+			// This should detect a trap since there is a lack of i64 values on the stack
+			name:        np + "Stack Underflow",
+			stackValues: []uint64{},
+			memoryContent: []byte{
+				wasmvm.OP_SUB_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Stack Underflow",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			// happy path - Small Numbers
+			name:        np + "Small Numbers",
+			stackValues: []uint64{uint64(7), uint64(5)},
+			memoryContent: []byte{
+				wasmvm.OP_SUB_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(2)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Overflow Wrap
+			// Going past 0 will wrap back to 0xffffffffffffffff, or in this case for -2 from 1 to 0xffffffffffffffff
+			name:        np + "Overflow Wrap",
+			stackValues: []uint64{uint64(1), uint64(2)},
+			memoryContent: []byte{
+				wasmvm.OP_SUB_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{^uint64(0)}, // ^uint64(0) or 0xffffffffffffffff is QWORD for -1
+			expectPC:      1,
+			expectedStack: 1,
+		},
 	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	// opcode
-	vm.Memory[0] = wasmvm.OP_ADD_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.Error(t, err)
-	assert.Equal(t, int(0), vm.ValueStack.Size())
-	assert.True(t, vm.Trap)
-	assert.Equal(t, "ADD_I64: Stack Underflow", vm.TrapReason)
+	runTestBatchI64(t, tests)
 }
 
-func TestADD_I64_SmallNumbers(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 1,
+// Tests for mul.i64
+func TestMUL_I64(t *testing.T) {
+	np := "MUL_I64: "
+	tests := []i64TestCase{
+		{
+			// This should detect a trap since there is a lack of i64 values on the stack
+			name:        np + "Stack Underflow",
+			stackValues: []uint64{},
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Stack Underflow",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			// happy path - Small Numbers
+			name:        np + "Small Numbers",
+			stackValues: []uint64{uint64(7), uint64(5)},
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(35)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Overflow Wrap
+			// Going past 0xffffffffffffffff will wrap back to 0xfffffffffffffffe
+			name:        np + "Overflow Wrap",
+			stackValues: []uint64{^uint64(0), uint64(2)}, // ^uint64(0) or 0xffffffffffffffff is QWORD for -1
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap: false,
+			// 0xFFFFFFFFFFFFFFFF * 2 = 0xFFFFFFFFFFFFFFFE (wraps as unsigned), which as int64 is -2
+			expectValue:   []uint64{^uint64(0) - 1},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Multiply by 0
+			// The typical whatever * 0 = 0
+			name:        np + "Multiply by 0",
+			stackValues: []uint64{uint64(137), uint64(0)},
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Multiply by 0
+			// The typical whatever * 1 = whatever
+			name:        np + "Multiply by 1",
+			stackValues: []uint64{uint64(0x123456789ABCDEF), uint64(1)},
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0x123456789ABCDEF)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Positive times Negative
+			// The typical 7 * -3 = -21
+			name:        np + "Positive times Negative",
+			stackValues: []uint64{uint64(7), (^uint64(0) - 2)}, // QWord -1 then -2 = -3 or 0xFFFFFFFFFFFFFFFD
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{(^uint64(0) - 20)}, // QWord -21 or 0xFFFFFFFFFFFFFFEB
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			// happy path - Negative times Negative
+			// The typical -2 * -4 = 8
+			name:        np + "Positive times Negative",
+			stackValues: []uint64{(^uint64(0) - 1), (^uint64(0) - 3)}, // QWord -2 and -4 respectively
+			memoryContent: []byte{
+				wasmvm.OP_MUL_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(8)}, // Negative times negative equals positive
+			expectPC:      1,
+			expectedStack: 1,
+		},
 	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-
-	vm.ValueStack.PushInt64(5)
-	vm.ValueStack.PushInt64(7)
-	// opcode
-	vm.Memory[0] = wasmvm.OP_ADD_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, success := vm.ValueStack.Pop()
-	assert.True(t, success)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, uint64(12), val.Value_I64)
-	assert.Equal(t, int(0), vm.ValueStack.Size())
+	runTestBatchI64(t, tests)
 }
 
-func TestADD_I64_OverflowWrap(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 1,
+// Table tests for div_u.i64
+func TestDIVU_I64(t *testing.T) {
+	np := "DIVU_I64: "
+	tests := []i64TestCase{
+		{
+			name:        np + "Divide By Zero",
+			stackValues: []uint64{1, 0},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Divide by Zero",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			name:        np + "Small Values - Exact",
+			stackValues: []uint64{10, 5},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{2},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Small Values - Non-Exact",
+			stackValues: []uint64{11, 5},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{2},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Stack Underflow",
+			stackValues: []uint64{uint64(1)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Stack Underflow",
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "One by One",
+			stackValues: []uint64{1, 1},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{1},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Max value by itself",
+			stackValues: []uint64{^uint64(0), ^uint64(0)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{1},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Large by One",
+			stackValues: []uint64{uint64(math.MaxInt64), 1},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(math.MaxInt64)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Large by Large - Overflows to 1",
+			stackValues: []uint64{uint64(math.MaxInt64), uint64(math.MaxInt64)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(1)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Zero Dividend",
+			stackValues: []uint64{uint64(0), uint64(42)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Dividend Smaller than Divisor",
+			stackValues: []uint64{uint64(41), uint64(42)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVU_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
 	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(^uint64(0)) // I didn't feel like typing a bunch of f's
-	vm.ValueStack.PushInt64(2)
-	// opcode
-	vm.Memory[0] = wasmvm.OP_ADD_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, success := vm.ValueStack.Pop()
-	assert.True(t, success)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, uint64(1), val.Value_I64)
-	assert.Equal(t, int(0), vm.ValueStack.Size())
+	runTestBatchI64(t, tests)
 }
 
-func TestSUB_I64_NotEnoughStack(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 1,
+/*
+// This was copied over and modified from i32 tests.
+// Once verified, it will be useable for testing div_s.i64
+// Table tests for div_s.i64
+func TestDIVS_I64(t *testing.T) {
+	np := "DIVS_I64: "
+	tests := []i64TestCase{
+		{
+			name:        np + "Divide By Zero",
+			stackValues: []uint64{1, 0},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Divide by Zero",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			name:        np + "Small Values - Exact",
+			stackValues: []uint64{10, 5},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{2},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Small Values - Non-Exact",
+			stackValues: []uint64{11, 5},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{2},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Min Negative by Negative One Division Overflow Trap",
+			stackValues: []uint64{uint64(0x8000000000000000), ^uint64(0)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Signed Division Overflow",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			name:        np + "Stack Underflow",
+			stackValues: []uint64{uint64(1)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Stack Underflow",
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Positive One by Positive One",
+			stackValues: []uint64{1, 1},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{1},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Positive One by Negative One",
+			stackValues: []uint64{1, ^uint64(0)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{^uint64(0)}, // QWord for -1
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Negative One by Positive One",
+			stackValues: []uint64{^uint64(0), 1},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{^uint64(0)}, // QWord for -1
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Negative One by Negative One",
+			stackValues: []uint64{^uint64(0), ^uint64(0)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{1},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Max Positive by Positive One",
+			stackValues: []uint64{uint64(math.MaxInt64), 1},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(math.MaxInt64)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Max Positive by Negative One",
+			stackValues: []uint64{uint64(math.MaxInt64), ^uint64(0)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0x8000000000000001)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Max Positive by Max Positive",
+			stackValues: []uint64{uint64(math.MaxInt64), uint64(math.MaxInt64)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(1)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Zero Dividend",
+			stackValues: []uint64{uint64(0), uint64(42)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Dividend Smaller than Divisor",
+			stackValues: []uint64{uint64(41), uint64(42)},
+			memoryContent: []byte{
+				wasmvm.OP_DIVS_I64,
+			},
+			expectTrap:    false,
+			expectValue:   []uint64{uint64(0)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
 	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	// opcode
-	vm.Memory[0] = wasmvm.OP_SUB_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.Error(t, err)
-	assert.Equal(t, int(0), vm.ValueStack.Size())
-	assert.True(t, vm.Trap)
-	assert.Equal(t, "SUB_I64: Stack Underflow", vm.TrapReason)
+	runTestBatchI64(t, tests)
 }
-
-func TestSUB_I64_SmallNumbers(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 1,
-	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(7)
-	vm.ValueStack.PushInt64(5)
-	// opcode
-	vm.Memory[0] = wasmvm.OP_SUB_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, success := vm.ValueStack.Pop()
-	assert.True(t, success)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, uint64(2), val.Value_I64)
-	assert.Equal(t, int(0), vm.ValueStack.Size())
-}
-
-func TestSUB_I64_OverflowWrap(t *testing.T) {
-	cfg := &wasmvm.VMConfig{
-		Size: 1,
-	}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(1)
-	vm.ValueStack.PushInt64(2)
-	// opcode
-	vm.Memory[0] = wasmvm.OP_SUB_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, success := vm.ValueStack.Pop()
-	assert.True(t, success)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, ^uint64(0), val.Value_I64) // Short hand for all f;s
-	assert.Equal(t, int(0), vm.ValueStack.Size())
-}
-
-func TestMUL_I64_NotEnoughStack(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.Memory[0] = wasmvm.OP_MUL_I64 // MUL_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.Error(t, err)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-	assert.True(t, vm.Trap)
-	assert.Equal(t, "MUL_I64: Stack Underflow", vm.TrapReason)
-}
-
-func TestMUL_I64_MultiplyByZero(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(12345)
-	vm.ValueStack.PushInt64(0)
-	vm.Memory[0] = wasmvm.OP_MUL_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(0), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestMUL_I64_MultiplyByOne(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(1)
-	vm.ValueStack.PushInt64(0x0123456789ABCDEF)
-	vm.Memory[0] = wasmvm.OP_MUL_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(0x0123456789ABCDEF), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestMUL_I64_PositiveTimesNegative(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(7)
-	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFD) // QWORD decimal -3
-	vm.Memory[0] = wasmvm.OP_MUL_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(0xFFFFFFFFFFFFFFEB), val.Value_I64) // QWORD decimal -21
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestMUL_I64_NegativeTimesNegative(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFE) // QWORD decimal -2
-	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFC) // QWORD decimal -4
-	vm.Memory[0] = wasmvm.OP_MUL_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(8), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestMUL_I64_OverflowWrap(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(0xFFFFFFFFFFFFFFFF) // QWORD decimal -1
-	vm.ValueStack.PushInt64(2)
-	vm.Memory[0] = wasmvm.OP_MUL_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	// 0xFFFFFFFFFFFFFFFF * 2 = 0xFFFFFFFFFFFFFFFE (wraps as unsigned), which as int64 is -2
-	assert.Equal(t, ^uint64(0)-1, val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestDIVU_I64_DivideByZero(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(1)
-	vm.ValueStack.PushInt64(0)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.Error(t, err)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-	assert.True(t, vm.Trap)
-	assert.Equal(t, "DIVU_I64: Divide by Zero", vm.TrapReason)
-}
-
-func TestDIVU_I64_StackUnderflow(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(1)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.Error(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	assert.True(t, vm.Trap)
-	assert.Equal(t, "DIVU_I64: Stack Underflow", vm.TrapReason)
-}
-
-func TestDIVU_I64_SmallValues(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(10)
-	vm.ValueStack.PushInt64(5)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(2), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestDIVU_I64_DivideByOne(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(42)
-	vm.ValueStack.PushInt64(1)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(42), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestDIVU_I64_DivisorLargerThanDividend(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(42)
-	vm.ValueStack.PushInt64(137)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(0), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestDIVU_I64_ZeroDividend(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(0)
-	vm.ValueStack.PushInt64(137)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(0), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestDIVU_I64_MaxValueBySelf(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(^uint64(0))
-	vm.ValueStack.PushInt64(^uint64(0))
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, uint64(1), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
-
-func TestDIVU_I64_MaxValueByOnef(t *testing.T) {
-	cfg := &wasmvm.VMConfig{Size: 1}
-	vm, err := wasmvm.NewVM(cfg)
-	assert.NoError(t, err)
-	vm.ValueStack.PushInt64(^uint64(0))
-	vm.ValueStack.PushInt64(1)
-	vm.Memory[0] = wasmvm.OP_DIVU_I64
-	vm.PC = 0
-	err = vm.Step()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, vm.ValueStack.Size())
-	val, ok := vm.ValueStack.Pop()
-	assert.True(t, ok)
-	assert.Equal(t, ^uint64(0), val.Value_I64)
-	assert.Equal(t, uint64(1), vm.PC)
-	assert.Equal(t, 0, vm.ValueStack.Size())
-}
+*/


### PR DESCRIPTION
The div_s.i64 was left commented out since the instruction doesn't exists yet. No overall change in code coverage.