### PR TITLE
RWV-22 implement i32.rem_u opcode

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,6 @@ done were omitted.
 - Status: In Progress
 - Child tasks:
 - RWV-21 - Implement `i32.rem_s` opcode
-- RWV-22 - Implement `i32.rem_u` opcode
 - RWV-23 - Implement `i64.rem_s` opcode
 - RWV-24 - Implement `i64.rem_u` opcode
 
@@ -35,6 +34,7 @@ done were omitted.
 - Child tasks:
 - RWV-18 - Replace `VMConfig.FlatMemory` with a Memory Compositor (`ON HOLD`)
 - RWV-20 - Improve pull request validation performance in GitHub Actions
+- RWV-56 - Replace `InstructionMap` with opcode dispatch table and add invalid/not-implemented handlers
 
 ### RWV-25 - Implement integer bitwise opcodes for i32 and i64
 

--- a/pkg/wasmvm/instruct_numeric_i32.go
+++ b/pkg/wasmvm/instruct_numeric_i32.go
@@ -184,3 +184,35 @@ func DIVU_I32(vm *VMState) error {
 	vm.PC += 1
 	return nil
 }
+
+// 0x70 rem_u.i32: Pull two I32 words off stack, push I32 remainder word on stack (unsigned)
+func REMU_I32(vm *VMState) error {
+	enough, collect := vm.ValueStack.HasAtLeastOfType(2, TYPE_I32)
+	if !enough {
+		return NewStackUnderflowErrorAndSetTrap(vm, "REMU_I32")
+	}
+
+	// I'm not even sure how I can write an unit test for this
+	// one, especially since there is no multithreading and
+	// the instruction treats it as an atomic operation
+	if !vm.ValueStack.Drop(2, true) {
+		return NewStackCleanupErrorAndSetTrap(vm, "REMU_I32")
+	}
+
+	dividend := collect[0].Value_I32
+	divisor := collect[1].Value_I32
+
+	if divisor == 0 {
+		return vm.SetTrapError(&TrapError{
+			Type:    TrapDivideByZero,
+			Op:      "REMU_I32",
+			PC:      vm.PC,
+			Message: "REMU_I32: Divide by Zero",
+		})
+	}
+
+	_, accumulator := bits.Div32(uint32(0), dividend, divisor)
+	vm.ValueStack.PushInt32(accumulator)
+	vm.PC += 1
+	return nil
+}

--- a/pkg/wasmvm/instruct_numeric_i32_test.go
+++ b/pkg/wasmvm/instruct_numeric_i32_test.go
@@ -430,6 +430,128 @@ func TestDIVU_I32(t *testing.T) {
 	runTestBatchI32(t, tests)
 }
 
+// Table tests for rem_u.i32
+func TestREMU_I32(t *testing.T) {
+	np := "REMU_I32: "
+	tests := []i32TestCase{
+		{
+			name:        np + "Divide By Zero",
+			stackValues: []uint32{1, 0},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Divide by Zero",
+			trapType:      wasmvm.TrapDivideByZero,
+			trapOp:        "REMU_I32",
+			expectPC:      0,
+			expectedStack: 0,
+		},
+		{
+			name:        np + "Small Values - Exact",
+			stackValues: []uint32{10, 5},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{0},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Small Values - Non-Exact",
+			stackValues: []uint32{11, 5},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{1},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Stack Underflow",
+			stackValues: []uint32{uint32(1)},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    true,
+			trapReason:    np + "Stack Underflow",
+			trapType:      wasmvm.TrapStackUnderflow,
+			trapOp:        "REMU_I32",
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "One by One",
+			stackValues: []uint32{1, 1},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{0},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Max value by itself",
+			stackValues: []uint32{^uint32(0), ^uint32(0)},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{0},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Large by One",
+			stackValues: []uint32{uint32(math.MaxInt32), 1},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{0},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Large by Large - Remainder 0",
+			stackValues: []uint32{uint32(math.MaxInt32), uint32(math.MaxInt32)},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{0},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Zero Dividend",
+			stackValues: []uint32{uint32(0), uint32(42)},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{uint32(0)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+		{
+			name:        np + "Dividend Smaller than Divisor",
+			stackValues: []uint32{uint32(41), uint32(42)},
+			memoryContent: []byte{
+				wasmvm.OP_REMU_I32,
+			},
+			expectTrap:    false,
+			expectValue:   []uint32{uint32(41)},
+			expectPC:      1,
+			expectedStack: 1,
+		},
+	}
+	runTestBatchI32(t, tests)
+}
+
 // Table tests for div_s.i32
 func TestDIVS_I32(t *testing.T) {
 	np := "DIVS_I32: "

--- a/pkg/wasmvm/instruction.go
+++ b/pkg/wasmvm/instruction.go
@@ -17,6 +17,7 @@ const (
 	OP_MUL_I32  = 0x6C
 	OP_DIVS_I32 = 0x6D
 	OP_DIVU_I32 = 0x6E
+	OP_REMU_I32 = 0x70
 
 	// Numeric I64 arithmatic instructions
 	OP_ADD_I64  = 0x7C
@@ -37,6 +38,7 @@ func defaultInstructionMap() map[uint8]Instruction {
 		OP_MUL_I32:   MUL_I32,
 		OP_DIVS_I32:  DIVS_I32,
 		OP_DIVU_I32:  DIVU_I32,
+		OP_REMU_I32:  REMU_I32,
 		OP_ADD_I64:   ADD_I64,
 		OP_SUB_I64:   SUB_I64,
 		OP_MUL_I64:   MUL_I64,


### PR DESCRIPTION
## Summary
- add support for the WebAssembly `i32.rem_u` opcode
- register opcode `0x70` in the VM instruction map
- implement unsigned remainder behavior and divide-by-zero trapping
- add unit tests for exact, non-exact, underflow, zero-dividend, and equal-operand cases

## Validation
- `go test ./...`
- `go test ./... -coverprofile=...`
- `go tool cover -func=...`
- `go run ./cmd/wasmvm`

## Coverage
- `cmd/wasmvm`: 57.1%
- `pkg/wasmvm`: 94.8%
- overall: 93.3%

Warning: Codex (GPT) was used in the development of this branch.